### PR TITLE
New dispatcher with externally defined metrics (#344)

### DIFF
--- a/sensors-core/src/main/scala/akka/sensors/BasicMetricBuilders.scala
+++ b/sensors-core/src/main/scala/akka/sensors/BasicMetricBuilders.scala
@@ -28,7 +28,8 @@ trait BasicMetricBuilders {
 }
 
 object BasicMetricBuilders {
-  val ForActors: BasicMetricBuilders = make("akka_sensors", "actor")
+  val ForActors: BasicMetricBuilders      = make("akka_sensors", "actor")
+  val ForDispatchers: BasicMetricBuilders = make("akka_sensors", "dispatchers")
 
   private final class Impl(nameSpace: String, subSystem: String) extends BasicMetricBuilders {
     override val namespace: String = nameSpace

--- a/sensors-core/src/main/scala/akka/sensors/DispatcherMetrics.scala
+++ b/sensors-core/src/main/scala/akka/sensors/DispatcherMetrics.scala
@@ -1,0 +1,62 @@
+package akka.sensors
+
+import io.prometheus.client.{Collector, CollectorRegistry, Gauge, Histogram}
+
+final case class DispatcherMetrics(
+  queueTime: Histogram,
+  runTime: Histogram,
+  activeThreads: Histogram,
+  threadStates: Gauge,
+  threads: Gauge,
+  executorValue: Gauge
+) {
+  val allCollectors: List[Collector] = List(queueTime, runTime, activeThreads, threadStates, threads, executorValue)
+}
+
+object DispatcherMetrics {
+  def make(metricsBuilders: BasicMetricBuilders): DispatcherMetrics = {
+    import metricsBuilders._
+
+    DispatcherMetrics(
+      queueTime = millisHistogram
+        .name("queue_time_millis")
+        .help(s"Milliseconds in queue")
+        .labelNames("dispatcher")
+        .create(),
+      runTime = millisHistogram
+        .name("run_time_millis")
+        .help(s"Milliseconds running")
+        .labelNames("dispatcher")
+        .create(),
+      activeThreads = valueHistogram(max = 32)
+        .name("active_threads")
+        .help(s"Active worker threads")
+        .labelNames("dispatcher")
+        .create(),
+      threadStates = gauge
+        .name("thread_states")
+        .help("Threads per state and dispatcher")
+        .labelNames("dispatcher", "state")
+        .create(),
+      threads = gauge
+        .name("threads_total")
+        .help("Threads per dispatcher")
+        .labelNames("dispatcher")
+        .create(),
+      executorValue = gauge
+        .name("executor_value")
+        .help("Internal executor values per type")
+        .labelNames("dispatcher", "value")
+        .create()
+    )
+  }
+
+  def register(metrics: DispatcherMetrics, cr: CollectorRegistry): Unit =
+    metrics.allCollectors.foreach(cr.register)
+
+  def makeAndRegister(metricBuilders: BasicMetricBuilders, cr: CollectorRegistry): DispatcherMetrics = {
+    val metrics = make(metricBuilders)
+    register(metrics, cr)
+    metrics
+  }
+}

--- a/sensors-core/src/main/scala/akka/sensors/SensorMetrics.scala
+++ b/sensors-core/src/main/scala/akka/sensors/SensorMetrics.scala
@@ -40,82 +40,91 @@ final case class SensorMetrics(
 
 object SensorMetrics {
   def makeAndRegister(metricBuilders: BasicMetricBuilders, cr: CollectorRegistry): SensorMetrics = {
+    val metrics = make(metricBuilders)
+    register(metrics, cr)
+    metrics
+  }
+
+  def make(metricBuilders: BasicMetricBuilders): SensorMetrics = {
     import metricBuilders._
     SensorMetrics(
       activityTime = secondsHistogram
         .name("activity_time_seconds")
         .help(s"Seconds of activity")
         .labelNames("actor")
-        .register(cr),
+        .create(),
       activeActors = gauge
         .name("active_actors_total")
         .help(s"Active actors")
         .labelNames("actor")
-        .register(cr),
+        .create(),
       unhandledMessages = counter
         .name("unhandled_messages_total")
         .help(s"Unhandled messages")
         .labelNames("actor", "message")
-        .register(cr),
+        .create(),
       exceptions = counter
         .name("exceptions_total")
         .help(s"Exceptions thrown by actors")
         .labelNames("actor")
-        .register(cr),
+        .create(),
       receiveTime = millisHistogram
         .name("receive_time_millis")
         .help(s"Millis to process receive")
         .labelNames("actor", "message")
-        .register(cr),
+        .create(),
       receiveTimeouts = counter
         .name("receive_timeouts_total")
         .help("Number of receive timeouts")
         .labelNames("actor")
-        .register(cr),
+        .create(),
       clusterEvents = counter
         .name("cluster_events_total")
         .help(s"Number of cluster events, per type")
         .labelNames("event", "member")
-        .register(cr),
+        .create(),
       clusterMembers = gauge
         .name("cluster_members_total")
         .help(s"Cluster members")
-        .register(cr),
+        .create(),
       recoveryTime = millisHistogram
         .name("recovery_time_millis")
         .help(s"Millis to process recovery")
         .labelNames("actor")
-        .register(cr),
+        .create(),
       persistTime = millisHistogram
         .name("persist_time_millis")
         .help(s"Millis to process single event persist")
         .labelNames("actor", "event")
-        .register(cr),
+        .create(),
       recoveries = counter
         .name("recoveries_total")
         .help(s"Recoveries by actors")
         .labelNames("actor")
-        .register(cr),
+        .create(),
       recoveryEvents = counter
         .name("recovery_events_total")
         .help(s"Recovery events by actors")
         .labelNames("actor")
-        .register(cr),
+        .create(),
       persistFailures = counter
         .name("persist_failures_total")
         .help(s"Persist failures")
         .labelNames("actor")
-        .register(cr),
+        .create(),
       recoveryFailures = counter
         .name("recovery_failures_total")
         .help(s"Recovery failures")
         .labelNames("actor")
-        .register(cr),
+        .create(),
       persistRejects = counter
         .name("persist_rejects_total")
         .help(s"Persist rejects")
         .labelNames("actor")
-        .register(cr)
+        .create()
     )
   }
+
+  def register(metrics: SensorMetrics, cr: CollectorRegistry): Unit =
+    metrics.allCollectors.foreach(cr.register)
 }

--- a/sensors-core/src/main/scala/akka/sensors/dispatch/DispatcherMetricsRegistration.scala
+++ b/sensors-core/src/main/scala/akka/sensors/dispatch/DispatcherMetricsRegistration.scala
@@ -1,0 +1,18 @@
+package akka.sensors.dispatch
+
+import akka.sensors.{DispatcherMetrics, MetricsBuilders}
+import io.prometheus.client.{Gauge, Histogram}
+
+/** Creates and registers Dispatcher metrics in the global registry */
+private[dispatch] object DispatcherMetricsRegistration extends MetricsBuilders {
+  def namespace: String = "akka_sensors"
+  def subsystem: String = "dispatchers"
+
+  private val metrics          = DispatcherMetrics.makeAndRegister(this, registry)
+  def queueTime: Histogram     = metrics.queueTime
+  def runTime: Histogram       = metrics.runTime
+  def activeThreads: Histogram = metrics.activeThreads
+  def threadStates: Gauge      = metrics.threadStates
+  def threads: Gauge           = metrics.threads
+  def executorValue: Gauge     = metrics.executorValue
+}

--- a/sensors-core/src/main/scala/akka/sensors/dispatch/InstrumentedDispatchers.scala
+++ b/sensors-core/src/main/scala/akka/sensors/dispatch/InstrumentedDispatchers.scala
@@ -14,47 +14,6 @@ import io.prometheus.client.{Gauge, Histogram}
 import scala.PartialFunction.condOpt
 import scala.concurrent.duration.{Duration, FiniteDuration}
 
-object DispatcherMetrics extends MetricsBuilders {
-  def namespace: String = "akka_sensors"
-  def subsystem: String = "dispatchers"
-
-  val queueTime: Histogram = millisHistogram
-    .name("queue_time_millis")
-    .help(s"Milliseconds in queue")
-    .labelNames("dispatcher")
-    .register(registry)
-
-  val runTime: Histogram = millisHistogram
-    .name("run_time_millis")
-    .help(s"Milliseconds running")
-    .labelNames("dispatcher")
-    .register(registry)
-
-  val activeThreads: Histogram = valueHistogram(max = 32)
-    .name("active_threads")
-    .help(s"Active worker threads")
-    .labelNames("dispatcher")
-    .register(registry)
-
-  val threadStates: Gauge = gauge
-    .name("thread_states")
-    .help("Threads per state and dispatcher")
-    .labelNames("dispatcher", "state")
-    .register(registry)
-
-  val threads: Gauge = gauge
-    .name("threads_total")
-    .help("Threads per dispatcher")
-    .labelNames("dispatcher")
-    .register(registry)
-
-  val executorValue: Gauge = gauge
-    .name("executor_value")
-    .help("Internal executor values per type")
-    .labelNames("dispatcher", "value")
-    .register(registry)
-}
-
 object AkkaRunnableWrapper {
   def unapply(runnable: Runnable): Option[Run => Runnable] =
     condOpt(runnable) {
@@ -100,19 +59,18 @@ class DispatcherInstrumentationWrapper(config: Config) {
     }
     execute(RunnableWrapper(runnable, run))
   }
+}
 
-  object RunnableWrapper {
-
-    def apply(runnableParam: Runnable, r: Run): Runnable =
-      runnableParam match {
-        case AkkaRunnableWrapper(runnable)  => runnable(r)
-        case ScalaRunnableWrapper(runnable) => runnable(r)
-        case runnable                       => new Default(runnable, r)
-      }
-
-    class Default(self: Runnable, r: Run) extends Runnable {
-      def run(): Unit = r(() => self.run())
+object RunnableWrapper {
+  def apply(runnableParam: Runnable, r: Run): Runnable =
+    runnableParam match {
+      case AkkaRunnableWrapper(runnable)  => runnable(r)
+      case ScalaRunnableWrapper(runnable) => runnable(r)
+      case runnable                       => new Default(runnable, r)
     }
+
+  private class Default(self: Runnable, r: Run) extends Runnable {
+    def run(): Unit = r(() => self.run())
   }
 }
 
@@ -125,7 +83,7 @@ object DispatcherInstrumentationWrapper {
 
   val Empty: InstrumentedRun = () => () => () => ()
 
-  import DispatcherMetrics._
+  import DispatcherMetricsRegistration._
   def meteredRun(id: String): InstrumentedRun = {
     val currentWorkers = new LongAdder
     val queue          = queueTime.labels(id)
@@ -170,7 +128,7 @@ class InstrumentedExecutor(val config: Config, val prerequisites: DispatcherPrer
 
   override def createExecutorServiceFactory(id: String, threadFactory: ThreadFactory): ExecutorServiceFactory = {
     val esf = delegate.createExecutorServiceFactory(id, threadFactory)
-    import DispatcherMetrics._
+    import DispatcherMetricsRegistration._
     new ExecutorServiceFactory {
       def createExecutorService: ExecutorService = {
         val es = esf.createExecutorService
@@ -269,11 +227,11 @@ trait InstrumentedDispatcher extends Dispatcher {
 
       interestingStates foreach { state =>
         val stateLabel = state.toString.toLowerCase
-        DispatcherMetrics.threadStates
+        DispatcherMetricsRegistration.threadStates
           .labels(id, stateLabel)
           .set(threads.count(_.getThreadState.name().equalsIgnoreCase(stateLabel)))
       }
-      DispatcherMetrics.threads
+      DispatcherMetricsRegistration.threads
         .labels(id)
         .set(threads.length)
     }

--- a/sensors-core/src/main/scala/akka/sensors/metered/DispatcherInstrumentationWrapper.scala
+++ b/sensors-core/src/main/scala/akka/sensors/metered/DispatcherInstrumentationWrapper.scala
@@ -1,0 +1,73 @@
+package akka.sensors.metered
+
+import akka.sensors.dispatch.DispatcherInstrumentationWrapper.{InstrumentedRun, Run}
+import akka.sensors.dispatch.RunnableWrapper
+import akka.sensors.{DispatcherMetrics, RunnableWatcher}
+import com.typesafe.config.Config
+
+import java.util.concurrent.atomic.LongAdder
+import scala.concurrent.duration.Duration
+
+private[metered] class DispatcherInstrumentationWrapper(metrics: DispatcherMetrics, config: Config) {
+  import DispatcherInstrumentationWrapper._
+  import akka.sensors.dispatch.Helpers._
+
+  private val executorConfig = config.getConfig("instrumented-executor")
+
+  private val instruments: List[InstrumentedRun] =
+    List(
+      if (executorConfig.getBoolean("measure-runs")) Some(meteredRun(metrics, config.getString("id"))) else None,
+      if (executorConfig.getBoolean("watch-long-runs"))
+        Some(watchedRun(config.getString("id"), executorConfig.getMillisDuration("watch-too-long-run"), executorConfig.getMillisDuration("watch-check-interval")))
+      else None
+    ) flatten
+
+  def apply(runnable: Runnable, execute: Runnable => Unit): Unit = {
+    val beforeRuns = for { f <- instruments } yield f()
+    val run = new Run {
+      def apply[T](run: () => T): T = {
+        val afterRuns = for { f <- beforeRuns } yield f()
+        try run()
+        finally for { f <- afterRuns } f()
+      }
+    }
+    execute(RunnableWrapper(runnable, run))
+  }
+}
+private[metered] object DispatcherInstrumentationWrapper {
+  def meteredRun(metrics: DispatcherMetrics, id: String): InstrumentedRun = {
+    val currentWorkers = new LongAdder
+    val queue          = metrics.queueTime.labels(id)
+    val run            = metrics.runTime.labels(id)
+    val active         = metrics.activeThreads.labels(id)
+
+    () => {
+      val created = System.currentTimeMillis()
+      () => {
+        val started = System.currentTimeMillis()
+        queue.observe((started - created).toDouble)
+        currentWorkers.increment()
+        active.observe(currentWorkers.intValue())
+        () => {
+          val stopped = System.currentTimeMillis()
+          run.observe((stopped - started).toDouble)
+          currentWorkers.decrement()
+          active.observe(currentWorkers.intValue)
+          ()
+        }
+      }
+    }
+  }
+
+  private def watchedRun(id: String, tooLongThreshold: Duration, checkInterval: Duration): InstrumentedRun = {
+    val watcher = RunnableWatcher(tooLongRunThreshold = tooLongThreshold, checkInterval = checkInterval)
+
+    () => { () =>
+      val stop = watcher.start()
+      () => {
+        stop()
+        ()
+      }
+    }
+  }
+}

--- a/sensors-core/src/main/scala/akka/sensors/metered/MeteredDispatcher.scala
+++ b/sensors-core/src/main/scala/akka/sensors/metered/MeteredDispatcher.scala
@@ -1,0 +1,18 @@
+package akka.sensors.metered
+
+import akka.dispatch.Dispatcher
+import akka.sensors.DispatcherMetrics
+
+private[metered] class MeteredDispatcher(settings: MeteredDispatcherSettings)
+    extends Dispatcher(
+      settings._configurator,
+      settings.id,
+      settings.throughput,
+      settings.throughputDeadlineTime,
+      executorServiceFactoryProvider = settings.executorServiceFactoryProvider,
+      shutdownTimeout = settings.shutdownTimeout
+    )
+    with MeteredDispatcherInstrumentation {
+  protected override val actorSystemName: String    = settings.name
+  protected override val metrics: DispatcherMetrics = settings.metrics
+}

--- a/sensors-core/src/main/scala/akka/sensors/metered/MeteredDispatcherConfigurator.scala
+++ b/sensors-core/src/main/scala/akka/sensors/metered/MeteredDispatcherConfigurator.scala
@@ -1,0 +1,28 @@
+package akka.sensors.metered
+
+import akka.dispatch.{Dispatcher, DispatcherPrerequisites, MessageDispatcher, MessageDispatcherConfigurator}
+import akka.sensors.DispatcherMetrics
+import akka.sensors.dispatch.Helpers
+import com.typesafe.config.Config
+
+class MeteredDispatcherConfigurator(config: Config, prerequisites: DispatcherPrerequisites) extends MessageDispatcherConfigurator(config, prerequisites) {
+  import Helpers._
+
+  private val instance: MessageDispatcher = {
+    val _metrics = MeteredDispatcherSetup.setupOrThrow(prerequisites).metrics
+    val settings = MeteredDispatcherSettings(
+      name = prerequisites.mailboxes.settings.name,
+      metrics = _metrics,
+      _configurator = this,
+      id = config.getString("id"),
+      throughput = config.getInt("throughput"),
+      throughputDeadlineTime = config.getNanosDuration("throughput-deadline-time"),
+      executorServiceFactoryProvider = configureExecutor(),
+      shutdownTimeout = config.getMillisDuration("shutdown-timeout")
+    )
+
+    new MeteredDispatcher(settings)
+  }
+
+  def dispatcher(): MessageDispatcher = instance
+}

--- a/sensors-core/src/main/scala/akka/sensors/metered/MeteredDispatcherInstrumentation.scala
+++ b/sensors-core/src/main/scala/akka/sensors/metered/MeteredDispatcherInstrumentation.scala
@@ -1,0 +1,63 @@
+package akka.sensors.metered
+
+import akka.dispatch.{Dispatcher, Mailbox}
+import akka.event.Logging.Error
+import akka.sensors.{AkkaSensors, DispatcherMetrics}
+
+import java.lang.management.{ManagementFactory, ThreadMXBean}
+import java.util.concurrent.RejectedExecutionException
+
+private[metered] trait MeteredDispatcherInstrumentation extends Dispatcher {
+  protected def actorSystemName: String
+  protected def metrics: DispatcherMetrics
+
+  private lazy val wrapper               = new DispatcherInstrumentationWrapper(metrics, configurator.config)
+  private val threadMXBean: ThreadMXBean = ManagementFactory.getThreadMXBean
+  private val interestingStateNames      = Set("runnable", "waiting", "timed_waiting", "blocked")
+  private val interestingStates          = Thread.State.values.filter(s => interestingStateNames.contains(s.name().toLowerCase))
+
+  AkkaSensors.schedule(
+    s"$id-states",
+    () => {
+      val threads = threadMXBean
+        .getThreadInfo(threadMXBean.getAllThreadIds, 0)
+        .filter(t =>
+          t != null
+            && t.getThreadName.startsWith(s"$actorSystemName-$id")
+        )
+
+      interestingStates foreach { state =>
+        val stateLabel = state.toString.toLowerCase
+        metrics.threadStates
+          .labels(id, stateLabel)
+          .set(threads.count(_.getThreadState.name().equalsIgnoreCase(stateLabel)))
+      }
+      metrics.threads
+        .labels(id)
+        .set(threads.length)
+    }
+  )
+
+  override def execute(runnable: Runnable): Unit = wrapper(runnable, super.execute)
+
+  protected[akka] override def registerForExecution(mbox: Mailbox, hasMessageHint: Boolean, hasSystemMessageHint: Boolean): Boolean =
+    if (mbox.canBeScheduledForExecution(hasMessageHint, hasSystemMessageHint))
+      if (mbox.setAsScheduled())
+        try {
+          wrapper(mbox, executorService.execute)
+          true
+        } catch {
+          case _: RejectedExecutionException =>
+            try {
+              wrapper(mbox, executorService.execute)
+              true
+            } catch { //Retry once
+              case e: RejectedExecutionException =>
+                mbox.setAsIdle()
+                eventStream.publish(Error(e, getClass.getName, getClass, "registerForExecution was rejected twice!"))
+                throw e
+            }
+        }
+      else false
+    else false
+}

--- a/sensors-core/src/main/scala/akka/sensors/metered/MeteredDispatcherSettings.scala
+++ b/sensors-core/src/main/scala/akka/sensors/metered/MeteredDispatcherSettings.scala
@@ -1,0 +1,18 @@
+package akka.sensors.metered
+
+import akka.dispatch.MessageDispatcherConfigurator
+
+import scala.concurrent.duration._
+import akka.dispatch.ExecutorServiceFactoryProvider
+import akka.sensors.DispatcherMetrics
+
+private[metered] case class MeteredDispatcherSettings(
+  name: String,
+  metrics: DispatcherMetrics,
+  _configurator: MessageDispatcherConfigurator,
+  id: String,
+  throughput: Int,
+  throughputDeadlineTime: Duration,
+  executorServiceFactoryProvider: ExecutorServiceFactoryProvider,
+  shutdownTimeout: FiniteDuration
+)

--- a/sensors-core/src/main/scala/akka/sensors/metered/MeteredDispatcherSetup.scala
+++ b/sensors-core/src/main/scala/akka/sensors/metered/MeteredDispatcherSetup.scala
@@ -1,0 +1,16 @@
+package akka.sensors.metered
+
+import akka.actor.setup.Setup
+import akka.dispatch.DispatcherPrerequisites
+import akka.sensors.DispatcherMetrics
+
+final case class MeteredDispatcherSetup(metrics: DispatcherMetrics) extends Setup
+
+object MeteredDispatcherSetup {
+
+  /** Extract LocalDispatcherSetup out from DispatcherPrerequisites or throw an exception */
+  def setupOrThrow(prereq: DispatcherPrerequisites): MeteredDispatcherSetup =
+    prereq.settings.setup
+      .get[MeteredDispatcherSetup]
+      .getOrElse(throw SetupNotFound[MeteredDispatcherSetup])
+}

--- a/sensors-core/src/main/scala/akka/sensors/metered/MeteredInstrumentedExecutor.scala
+++ b/sensors-core/src/main/scala/akka/sensors/metered/MeteredInstrumentedExecutor.scala
@@ -1,0 +1,92 @@
+package akka.sensors.metered
+
+import akka.dispatch.{DispatcherPrerequisites, ExecutorServiceConfigurator, ExecutorServiceFactory, ForkJoinExecutorConfigurator, ThreadPoolExecutorConfigurator}
+import akka.sensors.AkkaSensors
+import com.typesafe.config.Config
+
+import java.util.concurrent.{ExecutorService, ForkJoinPool, ThreadFactory, ThreadPoolExecutor}
+
+class MeteredInstrumentedExecutor(val config: Config, val prerequisites: DispatcherPrerequisites) extends ExecutorServiceConfigurator(config, prerequisites) {
+  private val metrics = MeteredDispatcherSetup.setupOrThrow(prerequisites).metrics
+
+  private lazy val delegate: ExecutorServiceConfigurator =
+    serviceConfigurator(config.getString("instrumented-executor.delegate"))
+
+  override def createExecutorServiceFactory(id: String, threadFactory: ThreadFactory): ExecutorServiceFactory = {
+    val esf = delegate.createExecutorServiceFactory(id, threadFactory)
+    new ExecutorServiceFactory {
+      def createExecutorService: ExecutorService = {
+        val es = esf.createExecutorService
+
+        val activeCount       = metrics.executorValue.labels(id, "activeCount")
+        val corePoolSize      = metrics.executorValue.labels(id, "corePoolSize")
+        val largestPoolSize   = metrics.executorValue.labels(id, "largestPoolSize")
+        val maximumPoolSize   = metrics.executorValue.labels(id, "maximumPoolSize")
+        val queueSize         = metrics.executorValue.labels(id, "queueSize")
+        val completedTasks    = metrics.executorValue.labels(id, "completedTasks")
+        val poolSize          = metrics.executorValue.labels(id, "poolSize")
+        val steals            = metrics.executorValue.labels(id, "steals")
+        val parallelism       = metrics.executorValue.labels(id, "parallelism")
+        val queuedSubmissions = metrics.executorValue.labels(id, "queuedSubmissions")
+        val queuedTasks       = metrics.executorValue.labels(id, "queuedTasks")
+        val runningThreads    = metrics.executorValue.labels(id, "runningThreads")
+
+        es match {
+          case tp: ThreadPoolExecutor =>
+            AkkaSensors.schedule(
+              id,
+              () => {
+                activeCount.set(tp.getActiveCount)
+                corePoolSize.set(tp.getCorePoolSize)
+                largestPoolSize.set(tp.getLargestPoolSize)
+                maximumPoolSize.set(tp.getMaximumPoolSize)
+                queueSize.set(tp.getQueue.size())
+                completedTasks.set(tp.getCompletedTaskCount.toDouble)
+                poolSize.set(tp.getPoolSize)
+              }
+            )
+
+          case fj: ForkJoinPool =>
+            AkkaSensors.schedule(
+              id,
+              () => {
+                poolSize.set(fj.getPoolSize)
+                steals.set(fj.getStealCount.toDouble)
+                parallelism.set(fj.getParallelism)
+                activeCount.set(fj.getActiveThreadCount)
+                queuedSubmissions.set(fj.getQueuedSubmissionCount)
+                queuedTasks.set(fj.getQueuedTaskCount.toDouble)
+                runningThreads.set(fj.getRunningThreadCount)
+              }
+            )
+
+          case _ =>
+
+        }
+
+        es
+      }
+    }
+  }
+
+  private def serviceConfigurator(executor: String): ExecutorServiceConfigurator =
+    executor match {
+      case null | "" | "fork-join-executor" => new ForkJoinExecutorConfigurator(config.getConfig("fork-join-executor"), prerequisites)
+      case "thread-pool-executor"           => new ThreadPoolExecutorConfigurator(config.getConfig("thread-pool-executor"), prerequisites)
+      case fqcn =>
+        val args = List(classOf[Config] -> config, classOf[DispatcherPrerequisites] -> prerequisites)
+        prerequisites.dynamicAccess
+          .createInstanceFor[ExecutorServiceConfigurator](fqcn, args)
+          .recover({
+            case exception =>
+              throw new IllegalArgumentException(
+                """Cannot instantiate ExecutorServiceConfigurator ("executor = [%s]"), defined in [%s],
+                make sure it has an accessible constructor with a [%s,%s] signature"""
+                  .format(fqcn, config.getString("id"), classOf[Config], classOf[DispatcherPrerequisites]),
+                exception
+              )
+          })
+          .get
+    }
+
+}

--- a/sensors-core/src/main/scala/akka/sensors/metered/SetupNotFound.scala
+++ b/sensors-core/src/main/scala/akka/sensors/metered/SetupNotFound.scala
@@ -1,0 +1,17 @@
+package akka.sensors.metered
+
+import scala.reflect.ClassTag
+import scala.util.control.NoStackTrace
+
+trait SetupNotFound extends NoStackTrace
+
+object SetupNotFound {
+  private final case class Impl(msg: String) extends RuntimeException(msg) with SetupNotFound
+  private def errorMsg[T: ClassTag]: String = {
+    val className = implicitly[ClassTag[T]].runtimeClass.getName
+    s"Can't find dispatcher setup for '$className'." +
+      s" Please check if you have `$className` defined for your ActorSystem." +
+      s" Check ActorSystemSetup for more info."
+  }
+  def apply[T: ClassTag]: SetupNotFound = Impl(errorMsg[T])
+}

--- a/sensors-core/src/test/scala/akka/sensors/DispatcherMetricsSpec.scala
+++ b/sensors-core/src/test/scala/akka/sensors/DispatcherMetricsSpec.scala
@@ -1,0 +1,28 @@
+package akka.sensors
+
+import akka.sensors.MetricsTestUtils.{asMetricName, builder}
+import io.prometheus.client.CollectorRegistry
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.jdk.CollectionConverters._
+
+class DispatcherMetricsSpec extends AnyFreeSpec with Matchers {
+  "DispatcherMetrics" - {
+    "registers all metrics" in {
+      val cr = new CollectorRegistry(true)
+      DispatcherMetrics.makeAndRegister(builder, cr)
+      val samples = cr.metricFamilySamples().asIterator().asScala.toList
+      val names   = samples.map(_.name)
+
+      // Pay attention that counter metrics does not have `_total` suffixes
+      // Check io.prometheus.client.Counter.Builder.create(..) to see more
+      names should contain(asMetricName("queue_time_millis"))
+      names should contain(asMetricName("run_time_millis"))
+      names should contain(asMetricName("active_threads"))
+      names should contain(asMetricName("thread_states"))
+      names should contain(asMetricName("threads_total"))
+      names should contain(asMetricName("executor_value"))
+    }
+  }
+}

--- a/sensors-core/src/test/scala/akka/sensors/MetricsTestUtils.scala
+++ b/sensors-core/src/test/scala/akka/sensors/MetricsTestUtils.scala
@@ -1,0 +1,10 @@
+package akka.sensors
+
+private[sensors] object MetricsTestUtils {
+  val TestNameSpace: String        = "test_namespace"
+  val TestSubSystem: String        = "test_subsystem"
+  val builder: BasicMetricBuilders = BasicMetricBuilders.make(TestNameSpace, TestSubSystem)
+
+  def asMetricName(in: String): String =
+    s"${TestNameSpace}_${TestSubSystem}_$in"
+}

--- a/sensors-core/src/test/scala/akka/sensors/SensorMetricsSpec.scala
+++ b/sensors-core/src/test/scala/akka/sensors/SensorMetricsSpec.scala
@@ -5,18 +5,15 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers._
 
 import scala.jdk.CollectionConverters.IteratorHasAsScala
-import SensorMetricsSpec._
+import MetricsTestUtils._
 
 class SensorMetricsSpec extends AnyFreeSpec {
   "SensorMetrics" - {
     "registers all metrics" in {
       val cr      = new CollectorRegistry(true)
-      val builder = BasicMetricBuilders.make(TestNameSpace, TestSubSystem)
       val result  = SensorMetrics.makeAndRegister(builder, cr)
-
       val samples = cr.metricFamilySamples().asIterator().asScala.toList
-
-      val names = samples.map(_.name)
+      val names   = samples.map(_.name)
 
       // Pay attention that counter metrics does not have `_total` suffixes
       // Check io.prometheus.client.Counter.Builder.create(..) to see more
@@ -37,11 +34,4 @@ class SensorMetricsSpec extends AnyFreeSpec {
       names should contain(asMetricName("persist_rejects"))
     }
   }
-}
-
-object SensorMetricsSpec {
-  private val TestNameSpace = "test_namespace"
-  private val TestSubSystem = "test_subsystem"
-  private def asMetricName(in: String): String =
-    s"${TestNameSpace}_${TestSubSystem}_$in"
 }

--- a/sensors-core/src/test/scala/akka/sensors/metered/MeteredDispatcherConfiguratorSpec.scala
+++ b/sensors-core/src/test/scala/akka/sensors/metered/MeteredDispatcherConfiguratorSpec.scala
@@ -1,0 +1,53 @@
+package akka.sensors.metered
+
+import akka.ConfigurationException
+import akka.actor.BootstrapSetup
+import akka.actor.setup.ActorSystemSetup
+import akka.actor.typed.{ActorSystem, DispatcherSelector, SpawnProtocol}
+import akka.sensors.DispatcherMetrics
+import akka.sensors.MetricsTestUtils._
+import akka.sensors.metered.MeteredDispatcherConfiguratorSpec._
+import com.typesafe.config.ConfigFactory
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class MeteredDispatcherConfiguratorSpec extends AnyFreeSpec with Matchers {
+  "MeteredDispatcherConfigurator" - {
+    "is returned if configured(MeteredDispatcherSetup is defined)" in {
+      val metrics     = DispatcherMetrics.make(builder)
+      val withConfig  = BootstrapSetup(cfg)
+      val withMetrics = MeteredDispatcherSetup(metrics)
+      val setup       = ActorSystemSetup.create(withConfig, withMetrics)
+      val actorSystem = ActorSystem[SpawnProtocol.Command](SpawnProtocol(), "test-system", setup)
+      val dispatcher  = actorSystem.dispatchers.lookup(DispatcherSelector.defaultDispatcher())
+
+      try dispatcher shouldBe a[MeteredDispatcher]
+      finally actorSystem.terminate()
+    }
+
+    "throws SetupNotFound if MeteredDispatcherSetup is not defined" in {
+      val withConfig  = BootstrapSetup(cfg)
+      val setup       = ActorSystemSetup.create(withConfig)
+      def actorSystem = ActorSystem[SpawnProtocol.Command](SpawnProtocol(), "test-system", setup)
+
+      val exception = the[ConfigurationException] thrownBy actorSystem
+      exception.getCause shouldBe a[SetupNotFound]
+    }
+  }
+}
+
+object MeteredDispatcherConfiguratorSpec {
+  private val cfgStr =
+    """
+      |akka.actor.default-dispatcher {
+      |  type = "akka.sensors.metered.MeteredDispatcherConfigurator"
+      |  instrumented-executor {
+      |    delegate = "java.util.concurrent.ForkJoinPool"
+      |    measure-runs = false
+      |    watch-long-runs = false
+      |  }
+      |}
+      |""".stripMargin
+
+  private val cfg = ConfigFactory.parseString(cfgStr)
+}

--- a/sensors-core/src/test/scala/akka/sensors/metered/MeteredInstrumentedExecutorSpec.scala
+++ b/sensors-core/src/test/scala/akka/sensors/metered/MeteredInstrumentedExecutorSpec.scala
@@ -1,0 +1,53 @@
+package akka.sensors.metered
+
+import akka.ConfigurationException
+import akka.actor.BootstrapSetup
+import akka.actor.setup.ActorSystemSetup
+import akka.actor.typed.{ActorSystem, DispatcherSelector, SpawnProtocol}
+import akka.sensors.DispatcherMetrics
+import akka.sensors.MetricsTestUtils.builder
+import akka.sensors.metered.MeteredInstrumentedExecutorSpec._
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class MeteredInstrumentedExecutorSpec extends AnyFreeSpec with Matchers {
+  "MeteredInstrumentedExecutor" - {
+    "is returned if configured(MeteredDispatcherSetup is defined)" in {
+      val metrics     = DispatcherMetrics.make(builder)
+      val withConfig  = BootstrapSetup(cfg)
+      val withMetrics = MeteredDispatcherSetup(metrics)
+      val setup       = ActorSystemSetup.create(withConfig, withMetrics)
+      val actorSystem = ActorSystem[SpawnProtocol.Command](SpawnProtocol(), "test-system", setup)
+      val dispatcher  = actorSystem.dispatchers.lookup(DispatcherSelector.defaultDispatcher())
+
+      // do some execution to make sure that our executor is created
+      dispatcher.execute(() => ())
+    }
+
+    "throws SetupNotFound if MeteredDispatcherSetup is not defined" in {
+      val withConfig  = BootstrapSetup(cfg)
+      val setup       = ActorSystemSetup.create(withConfig)
+      def actorSystem = ActorSystem[SpawnProtocol.Command](SpawnProtocol(), "test-system", setup)
+
+      val exception = the[IllegalArgumentException] thrownBy actorSystem
+      exception.getCause shouldBe a[SetupNotFound]
+    }
+  }
+}
+
+object MeteredInstrumentedExecutorSpec {
+  import com.typesafe.config.ConfigFactory
+  private val cfgStr =
+    """
+      |akka.actor.default-dispatcher {
+      |  executor = "akka.sensors.metered.MeteredInstrumentedExecutor"
+      |  instrumented-executor {
+      |    delegate = "fork-join-executor"
+      |    measure-runs = false
+      |    watch-long-runs = false
+      |  }
+      |}
+      |""".stripMargin
+
+  private val cfg = ConfigFactory.parseString(cfgStr)
+}

--- a/sensors-core/src/test/scala/akka/sensors/metered/MeteredLogicSpec.scala
+++ b/sensors-core/src/test/scala/akka/sensors/metered/MeteredLogicSpec.scala
@@ -1,0 +1,75 @@
+package akka.sensors.metered
+
+import akka.actor.BootstrapSetup
+import akka.actor.typed.{ActorSystem, DispatcherSelector, SpawnProtocol}
+import akka.sensors.DispatcherMetrics
+import akka.sensors.MetricsTestUtils.{asMetricName, builder}
+import com.typesafe.config.ConfigFactory
+import io.prometheus.client.CollectorRegistry
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.jdk.CollectionConverters._
+import MeteredLogicSpec._
+import akka.actor.setup.ActorSystemSetup
+
+/**
+ * This spec contains checks for metrics gathering implemented in .metered package.
+ */
+class MeteredLogicSpec extends AnyFreeSpec with Matchers {
+  "Metered logic" - {
+    "collects metrics for runnables" in {
+      val cr      = new CollectorRegistry()
+      val metrics = DispatcherMetrics.make(builder)
+      metrics.allCollectors.foreach(cr.register)
+
+      val withConfig  = BootstrapSetup(cfg)
+      val withMetrics = MeteredDispatcherSetup(metrics)
+      val setup       = ActorSystemSetup.create(withConfig, withMetrics)
+      val actorSystem = ActorSystem[SpawnProtocol.Command](SpawnProtocol(), "test-system", setup)
+
+      try {
+        // here we get a metered dispatcher from a custom config
+        // Avoid using it as the default dispatcher as it is going to be used by Akka itself.
+        // In this case that usage will affect metrics we are testing
+        val dispatcher = actorSystem.dispatchers.lookup(DispatcherSelector.fromConfig("our-test-dispatcher"))
+
+        // check that samples in the metrics are not defined before running the test task
+        val prevSamples = cr.metricFamilySamples().asIterator().asScala.toList.map(in => (in.name, in)).toMap
+        prevSamples(asMetricName("queue_time_millis")).samples shouldBe empty
+        prevSamples(asMetricName("run_time_millis")).samples shouldBe empty
+        prevSamples(asMetricName("active_threads")).samples shouldBe empty
+        prevSamples(asMetricName("thread_states")).samples shouldBe empty
+        prevSamples(asMetricName("threads_total")).samples shouldBe empty
+        prevSamples(asMetricName("executor_value")).samples shouldBe empty
+
+        dispatcher.execute(() => Thread.sleep(3000))
+
+        //Now we can check that these metrics contain some samples after 3 secs of execution
+        val samples = cr.metricFamilySamples().asIterator().asScala.toList.map(in => (in.name, in)).toMap
+        samples(asMetricName("queue_time_millis")).samples should not be empty
+        samples(asMetricName("run_time_millis")).samples should not be empty
+        samples(asMetricName("active_threads")).samples should not be empty
+        samples(asMetricName("thread_states")).samples shouldBe empty
+        samples(asMetricName("threads_total")).samples shouldBe empty
+        samples(asMetricName("executor_value")).samples shouldBe empty
+      } finally actorSystem.terminate()
+    }
+  }
+}
+
+object MeteredLogicSpec {
+  private val cfgStr =
+    """
+      |our-test-dispatcher {
+      |  type = "akka.sensors.metered.MeteredDispatcherConfigurator"
+      |  instrumented-executor {
+      |    delegate = "java.util.concurrent.ForkJoinPool"
+      |    measure-runs = true
+      |    watch-long-runs = false
+      |  }
+      |}
+      |""".stripMargin
+
+  private val cfg = ConfigFactory.parseString(cfgStr)
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.5.0"
+ThisBuild / version := "0.5.1"


### PR DESCRIPTION
* preliminary refactoring for supporting local CollectorRegistry as well as a global one

* revert changes in build.sbt

* rename Metrics -> SensorMetrics

* adjustments between BasicMetricBuilders and MetricsBuilders

* add tests

* minor syntax improvements

* bump the version

* new impl of dispatchers with support of external Setup-s

* renamed Local* -> Metered* + minor changes here and there

* tests for initialisation of Metered* logic + minor refactoring of the new code

* test registration of all metrics from DispatcherMetrics

* test registration of all metrics from DispatcherMetrics

* test gathering metrics + nano refactoring

---------